### PR TITLE
RC_forecaster moduel now returns the reservoir states of the training data and of predicted time steps + fixed dependency on matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         'numpy>1.19.5',
         'scikit_learn>=1.4',
         'scipy',
-        'requests'
+        'requests',
+        'matplotlib',
     ],
     author="Filippo Maria Bianchi",
     author_email="filippombianchi@gmail.com",


### PR DESCRIPTION
commit 1: matplotlib addedin the list of required packages, used for plots in the notebooks
commit 2: RC_forecaster now returns the reservoir states of training data and of new predicted time steps, and two utility functions are added to retrieve the training and prediction reservoir states, respectively